### PR TITLE
feat: analyst charts + inspection detail page 

### DIFF
--- a/apps/web/src/app/(dashboard)/analyst/analytics/reclaimed/page.tsx
+++ b/apps/web/src/app/(dashboard)/analyst/analytics/reclaimed/page.tsx
@@ -1,18 +1,41 @@
 import { requireAnalyst } from '@/lib/auth.server';
 import { KpiCard } from '@/components/ui/KpiCard';
+import { UsageSplitChartSection } from '@/components/charts/UsageSplitChartSection';
 import db from '@/lib/db';
 import { Recycle, Droplets, Home, TrendingUp } from 'lucide-react';
 
 export default async function ReclaimedWaterPage() {
   await requireAnalyst();
 
-  const [totalAccounts, reclaimedAccounts, eligibleParcels] = await Promise.all([
+  const ninetyDaysAgo = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000);
+
+  const [totalAccounts, reclaimedAccounts, eligibleParcels, meterReads] = await Promise.all([
     db.customerAccount.count({ where: { isActive: true } }),
     db.customerAccount.count({ where: { isReclaimed: true, isActive: true } }),
     db.parcel.count({ where: { isReclaimedEligible: true } }),
+    db.meterRead.findMany({
+      where: { readTime: { gte: ninetyDaysAgo } },
+      select: { flow: true, label: true },
+    }),
   ]);
 
   const adoptionRate = totalAccounts > 0 ? ((reclaimedAccounts / totalAccounts) * 100).toFixed(1) : '0.0';
+
+  // Aggregate flow by type for pie chart
+  let potableFlow = 0;
+  let reclaimedFlow = 0;
+  for (const r of meterReads) {
+    const flow = r.flow ? Number(r.flow) : 0;
+    if (r.label === 'reclaimed') {
+      reclaimedFlow += flow;
+    } else {
+      potableFlow += flow;
+    }
+  }
+  const usageSplitData = [
+    { name: 'Potable', value: Math.round(potableFlow) },
+    { name: 'Reclaimed', value: Math.round(reclaimedFlow) },
+  ];
 
   const reclaimedCustomers = await db.customerAccount.findMany({
     where: { isReclaimed: true, isActive: true },
@@ -33,6 +56,9 @@ export default async function ReclaimedWaterPage() {
         <KpiCard label="Eligible Parcels" value={eligibleParcels} sub="Infrastructure available" icon={Home} />
         <KpiCard label="Total Active" value={totalAccounts} sub="All active accounts" icon={Droplets} />
       </div>
+
+      <UsageSplitChartSection data={usageSplitData} />
+
       <div className="bg-white rounded-xl border border-slate-200 overflow-hidden">
         <table className="w-full text-sm">
           <thead className="bg-slate-50 border-b border-slate-200">

--- a/apps/web/src/app/(dashboard)/analyst/analytics/usage/page.tsx
+++ b/apps/web/src/app/(dashboard)/analyst/analytics/usage/page.tsx
@@ -1,5 +1,6 @@
 import { requireAnalyst } from '@/lib/auth.server';
 import { KpiCard } from '@/components/ui/KpiCard';
+import { ZoneUsageChartSection } from '@/components/charts/ZoneUsageChartSection';
 import db from '@/lib/db';
 import { Droplets, MapPin, Home } from 'lucide-react';
 
@@ -12,6 +13,11 @@ export default async function UsageByZonePage() {
     db.parcel.groupBy({ by: ['wateringZone'], _count: { id: true }, orderBy: { _count: { id: 'desc' } } }),
   ]);
 
+  const zoneChartData = zoneCounts.map((z) => ({
+    zone: z.wateringZone ?? 'Unassigned',
+    count: z._count.id,
+  }));
+
   return (
     <div className="space-y-8">
       <div>
@@ -23,6 +29,9 @@ export default async function UsageByZonePage() {
         <KpiCard label="Reclaimed Eligible" value={reclaimedEligible} sub="Infrastructure available" icon={Droplets} variant="success" />
         <KpiCard label="Zone Groups" value={zoneCounts.length} sub="Distinct watering zones" icon={MapPin} />
       </div>
+
+      <ZoneUsageChartSection data={zoneChartData} />
+
       <div className="bg-white rounded-xl border border-slate-200 overflow-hidden">
         <table className="w-full text-sm">
           <thead className="bg-slate-50 border-b border-slate-200">

--- a/apps/web/src/app/(dashboard)/analyst/analytics/violations/page.tsx
+++ b/apps/web/src/app/(dashboard)/analyst/analytics/violations/page.tsx
@@ -1,5 +1,6 @@
 import { requireAnalyst } from '@/lib/auth.server';
 import { KpiCard } from '@/components/ui/KpiCard';
+import { ViolationTrendsCharts } from '@/components/charts/ViolationTrendsCharts';
 import db from '@/lib/db';
 import { TrendingUp, AlertTriangle, ShieldAlert, CheckCircle } from 'lucide-react';
 
@@ -8,17 +9,42 @@ export default async function ViolationTrendsPage() {
 
   const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
   const sixtyDaysAgo = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000);
+  const ninetyDaysAgo = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000);
 
-  const [total, last30, prev30, resolved, byType, byStatus] = await Promise.all([
+  const [total, last30, prev30, resolved, byType, byStatus, recentViolations] = await Promise.all([
     db.violation.count(),
     db.violation.count({ where: { detectedAt: { gte: thirtyDaysAgo } } }),
     db.violation.count({ where: { detectedAt: { gte: sixtyDaysAgo, lt: thirtyDaysAgo } } }),
     db.violation.count({ where: { status: 'RESOLVED' } }),
     db.violation.groupBy({ by: ['violationType'], _count: { id: true }, orderBy: { _count: { id: 'desc' } } }),
     db.violation.groupBy({ by: ['status'], _count: { id: true }, orderBy: { _count: { id: 'desc' } } }),
+    db.violation.findMany({
+      where: { detectedAt: { gte: ninetyDaysAgo } },
+      select: { detectedAt: true, violationType: true },
+      orderBy: { detectedAt: 'asc' },
+    }),
   ]);
 
   const trendPct = prev30 > 0 ? Math.round(((last30 - prev30) / prev30) * 100) : 0;
+
+  // Build weekly trend data server-side
+  const weekMap = new Map<string, number>();
+  for (const v of recentViolations) {
+    const d = new Date(v.detectedAt);
+    const weekStart = new Date(d);
+    weekStart.setDate(d.getDate() - d.getDay());
+    const key = weekStart.toISOString().slice(0, 10);
+    weekMap.set(key, (weekMap.get(key) ?? 0) + 1);
+  }
+  const trendData = Array.from(weekMap.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([week, count]) => ({ week, count }));
+
+  // Build type breakdown data server-side
+  const typeData = byType.map((v) => ({
+    type: v.violationType.replace(/_/g, ' '),
+    count: v._count.id,
+  }));
 
   return (
     <div className="space-y-8">
@@ -32,6 +58,9 @@ export default async function ViolationTrendsPage() {
         <KpiCard label="Prior 30 Days" value={prev30} sub="Comparison period" icon={ShieldAlert} />
         <KpiCard label="Resolved" value={resolved} sub="Closed violations" icon={CheckCircle} variant="success" />
       </div>
+
+      <ViolationTrendsCharts trendData={trendData} typeData={typeData} />
+
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div>
           <h2 className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-3">By Violation Type</h2>

--- a/apps/web/src/app/(dashboard)/analyst/dashboard/page.tsx
+++ b/apps/web/src/app/(dashboard)/analyst/dashboard/page.tsx
@@ -1,11 +1,11 @@
 import { requireAnalyst }  from '@/lib/auth.server';
 import { db }              from '@/lib/db';
 import { KpiCard }         from '@/components/ui/KpiCard';
+import { AnalystCharts }   from '@/components/charts/AnalystCharts';
 import { TrendingUp, Droplets, BarChart3, AlertTriangle } from 'lucide-react';
-import Link from 'next/link';
 
 export default async function AnalystDashboardPage() {
-  const user = await requireAnalyst();
+  await requireAnalyst();
 
   const [totalViolations, totalMeterReads, weekViolations, reclaimedAccounts] = await Promise.all([
     db.violation.count({ where: { status: { not: 'DISMISSED' } } }),
@@ -30,14 +30,7 @@ export default async function AnalystDashboardPage() {
         <KpiCard label="Reclaimed Accounts" value={reclaimedAccounts} icon={BarChart3}   variant="success" sub="Active connections" />
       </div>
 
-      <div className="bg-white rounded-xl border border-slate-200 p-8 text-center">
-        <BarChart3 className="w-10 h-10 text-slate-300 mx-auto mb-3" />
-        <p className="text-sm font-medium text-slate-600 mb-1">Charts Coming Next Sprint</p>
-        <p className="text-xs text-slate-400">Usage trends, zone comparisons, and reclaimed vs potable will render here</p>
-        <Link href="/enforcement/violations" className="inline-block mt-4 text-xs text-teal-600 font-medium hover:text-teal-700">
-          View violation data →
-        </Link>
-      </div>
+      <AnalystCharts />
     </div>
   );
 }

--- a/apps/web/src/app/(dashboard)/enforcement/inspections/[id]/InspectionActions.tsx
+++ b/apps/web/src/app/(dashboard)/enforcement/inspections/[id]/InspectionActions.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState }  from 'react';
+import { toast }     from 'sonner';
+import { cn }        from '@/lib/utils';
+
+/* ── Status transitions ────────────────────────────────── */
+
+const STATUS_FLOW: Record<string, { label: string; target: string; color: string }[]> = {
+  SCHEDULED:   [
+    { label: 'Begin Inspection', target: 'IN_PROGRESS', color: 'bg-blue-600 hover:bg-blue-500' },
+    { label: 'No Access',        target: 'NO_ACCESS',   color: 'bg-amber-600 hover:bg-amber-500' },
+    { label: 'Cancel',           target: 'CANCELLED',   color: 'bg-slate-500 hover:bg-slate-400' },
+  ],
+  IN_PROGRESS: [
+    { label: 'Mark Complete', target: 'COMPLETE',  color: 'bg-green-600 hover:bg-green-500' },
+    { label: 'No Access',    target: 'NO_ACCESS',  color: 'bg-amber-600 hover:bg-amber-500' },
+    { label: 'Cancel',       target: 'CANCELLED',  color: 'bg-slate-500 hover:bg-slate-400' },
+  ],
+  NO_ACCESS:   [
+    { label: 'Reschedule', target: 'SCHEDULED', color: 'bg-teal-600 hover:bg-teal-500' },
+    { label: 'Cancel',     target: 'CANCELLED', color: 'bg-slate-500 hover:bg-slate-400' },
+  ],
+};
+
+interface Props {
+  inspectionId: string;
+  currentStatus: string;
+  initialFindings: string;
+}
+
+export function InspectionActions({ inspectionId, currentStatus, initialFindings }: Props) {
+  const router = useRouter();
+  const [busy, setBusy]         = useState(false);
+  const [findings, setFindings] = useState(initialFindings);
+  const [saved, setSaved]       = useState(true);
+
+  const actions = STATUS_FLOW[currentStatus];
+  const isTerminal = currentStatus === 'COMPLETE' || currentStatus === 'CANCELLED';
+
+  async function patchInspection(body: Record<string, unknown>) {
+    setBusy(true);
+    try {
+      const res = await fetch(`/api/inspections/${inspectionId}`, {
+        method:  'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body:    JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || 'Update failed');
+      }
+      return true;
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : 'Update failed';
+      toast.error(msg);
+      return false;
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleStatusChange(target: string) {
+    const ok = await patchInspection({ status: target });
+    if (ok) {
+      toast.success(`Status updated to ${target.replace(/_/g, ' ')}`);
+      router.refresh();
+    }
+  }
+
+  async function handleSaveFindings() {
+    const ok = await patchInspection({ findings });
+    if (ok) {
+      toast.success('Findings saved');
+      setSaved(true);
+      router.refresh();
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* ── Inspector Notes / Findings ────────────────── */}
+      <div className="bg-white rounded-xl border border-slate-200 overflow-hidden">
+        <div className="px-5 py-3.5 border-b border-slate-100 bg-slate-50/50 flex items-center justify-between">
+          <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider">Inspector Notes</p>
+          {!saved && (
+            <span className="text-[10px] font-medium text-amber-600 bg-amber-50 px-2 py-0.5 rounded">Unsaved</span>
+          )}
+        </div>
+        <div className="p-5">
+          <textarea
+            value={findings}
+            onChange={(e) => { setFindings(e.target.value); setSaved(false); }}
+            disabled={busy || isTerminal}
+            placeholder={isTerminal ? 'No edits allowed on completed/cancelled inspections.' : 'Enter inspection findings, observations, and notes…'}
+            rows={5}
+            className={cn(
+              'w-full rounded-lg border border-slate-200 px-4 py-3 text-sm text-slate-900 placeholder:text-slate-400',
+              'focus:outline-none focus:ring-2 focus:ring-teal-500/20 focus:border-teal-400 transition-colors',
+              'resize-y disabled:bg-slate-50 disabled:cursor-not-allowed',
+            )}
+          />
+          {!isTerminal && (
+            <div className="flex justify-end mt-3">
+              <button
+                onClick={handleSaveFindings}
+                disabled={busy || saved}
+                className="px-4 py-2 bg-teal-600 hover:bg-teal-500 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors"
+              >
+                {busy ? 'Saving…' : 'Save Notes'}
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* ── Status Actions ────────────────────────────── */}
+      {actions && actions.length > 0 && (
+        <div className="bg-white rounded-xl border border-slate-200 p-5 space-y-3">
+          <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wider">Actions</h3>
+          <div className="flex flex-wrap gap-3">
+            {actions.map((a) => (
+              <button
+                key={a.target}
+                onClick={() => handleStatusChange(a.target)}
+                disabled={busy}
+                className={cn(
+                  'px-4 py-2 text-white text-sm font-medium rounded-lg transition-colors disabled:opacity-50',
+                  a.color,
+                )}
+              >
+                {busy ? 'Updating…' : a.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {isTerminal && (
+        <p className={cn(
+          'text-sm font-medium',
+          currentStatus === 'COMPLETE' ? 'text-green-600' : 'text-slate-400 italic',
+        )}>
+          {currentStatus === 'COMPLETE'
+            ? 'This inspection has been completed.'
+            : 'This inspection has been cancelled.'}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/enforcement/inspections/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/enforcement/inspections/[id]/page.tsx
@@ -1,0 +1,191 @@
+import { requireEnforcement } from '@/lib/auth.server';
+import { db }                from '@/lib/db';
+import { notFound }          from 'next/navigation';
+import Link                  from 'next/link';
+import { cn }                from '@/lib/utils';
+import { InspectionActions } from './InspectionActions';
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const STATUS_STYLES: Record<string, string> = {
+  SCHEDULED:   'bg-slate-50  text-slate-600  border-slate-200',
+  IN_PROGRESS: 'bg-blue-50   text-blue-700   border-blue-200',
+  COMPLETE:    'bg-green-50  text-green-700  border-green-200',
+  CANCELLED:   'bg-slate-50  text-slate-400  border-slate-200',
+  NO_ACCESS:   'bg-amber-50  text-amber-700  border-amber-200',
+};
+
+const VIOLATION_STATUS_STYLES: Record<string, string> = {
+  DETECTED:   'bg-amber-50  text-amber-700',
+  CONFIRMED:  'bg-orange-50 text-orange-700',
+  NOTIFIED:   'bg-blue-50   text-blue-700',
+  SR_CREATED: 'bg-purple-50 text-purple-700',
+  RESOLVED:   'bg-green-50  text-green-700',
+  DISMISSED:  'bg-slate-100 text-slate-400',
+};
+
+interface Props { params: Promise<{ id: string }> }
+
+export default async function InspectionDetailPage({ params }: Props) {
+  await requireEnforcement();
+  const { id } = await params;
+
+  const inspection = await db.inspection.findUnique({
+    where: { id },
+    include: {
+      violation:    true,
+      assignedUser: true,
+      complaints:   { orderBy: { createdAt: 'desc' }, take: 5 },
+    },
+  });
+
+  if (!inspection) notFound();
+
+  // Fetch all violations linked to this parcel for the violations table
+  const linkedViolations = await db.violation.findMany({
+    where: { parcelId: inspection.parcelId },
+    orderBy: { detectedAt: 'desc' },
+    take: 10,
+  });
+
+  const rows = [
+    { label: 'Address',        value: inspection.address },
+    { label: 'Parcel ID',      value: inspection.parcelId },
+    { label: 'Account ID',     value: inspection.accountId },
+    { label: 'Assigned To',    value: inspection.assignedUser
+        ? `${inspection.assignedUser.firstName} ${inspection.assignedUser.lastName}`
+        : 'Unassigned' },
+    { label: 'Scheduled Date', value: inspection.scheduledDate
+        ? new Date(inspection.scheduledDate).toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' })
+        : '—' },
+    { label: 'Completed Date', value: inspection.completedDate
+        ? new Date(inspection.completedDate).toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' })
+        : '—' },
+    { label: 'Cityworks WO',   value: inspection.cityworksWoId ?? 'Not created' },
+    { label: 'Source Violation', value: inspection.violation
+        ? inspection.violation.violationType.replace(/_/g, ' ')
+        : 'Manual inspection' },
+  ];
+
+  return (
+    <div className="max-w-3xl space-y-6">
+      {/* Breadcrumb */}
+      <div className="flex items-center gap-2 text-xs text-slate-500">
+        <Link href="/enforcement/inspections" className="hover:text-teal-600">Inspections</Link>
+        <span>/</span>
+        <span className="text-slate-900 font-medium">{id.slice(0, 8)}…</span>
+      </div>
+
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-xl font-bold text-slate-900">{inspection.address}</h1>
+          <p className="text-sm text-slate-500 mt-0.5">
+            Inspection — {inspection.scheduledDate
+              ? new Date(inspection.scheduledDate).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })
+              : 'Date TBD'}
+          </p>
+        </div>
+        <span className={cn('px-3 py-1 rounded-full text-xs font-bold border', STATUS_STYLES[inspection.status] ?? '')}>
+          {inspection.status.replace(/_/g, ' ')}
+        </span>
+      </div>
+
+      {/* Detail grid */}
+      <div className="bg-white rounded-xl border border-slate-200 overflow-hidden">
+        <div className="px-5 py-3.5 border-b border-slate-100 bg-slate-50/50">
+          <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider">Inspection Details</p>
+        </div>
+        <dl className="divide-y divide-slate-50">
+          {rows.map(row => (
+            <div key={row.label} className="flex items-center px-5 py-3 gap-4">
+              <dt className="w-40 shrink-0 text-xs font-semibold text-slate-500">{row.label}</dt>
+              <dd className="text-sm text-slate-900 font-mono">{String(row.value)}</dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+
+      {/* Actions + Notes (client) */}
+      <InspectionActions
+        inspectionId={id}
+        currentStatus={inspection.status}
+        initialFindings={inspection.findings ?? ''}
+      />
+
+      {/* Linked Violations */}
+      <div className="bg-white rounded-xl border border-slate-200 overflow-hidden">
+        <div className="px-5 py-3.5 border-b border-slate-100 bg-slate-50/50">
+          <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider">
+            Violations at this Parcel
+          </p>
+        </div>
+        {linkedViolations.length === 0 ? (
+          <div className="px-5 py-8 text-center text-sm text-slate-400">
+            No violations linked to this parcel.
+          </div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="bg-slate-50 border-b border-slate-200">
+              <tr>
+                <th className="text-left px-4 py-3 font-semibold text-slate-600">Type</th>
+                <th className="text-left px-4 py-3 font-semibold text-slate-600">Status</th>
+                <th className="text-left px-4 py-3 font-semibold text-slate-600">Detected</th>
+                <th className="text-left px-4 py-3 font-semibold text-slate-600">Read Value</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {linkedViolations.map((v: any) => (
+                <tr key={v.id} className="hover:bg-slate-50/50 transition-colors">
+                  <td className="px-4 py-3">
+                    <Link
+                      href={`/enforcement/violations/${v.id}`}
+                      className="font-medium text-teal-600 hover:text-teal-700"
+                    >
+                      {v.violationType.replace(/_/g, ' ')}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3">
+                    <span className={cn(
+                      'inline-flex items-center px-2 py-0.5 rounded text-xs font-medium',
+                      VIOLATION_STATUS_STYLES[v.status] ?? 'bg-slate-100 text-slate-600',
+                    )}>
+                      {v.status}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-slate-500">
+                    {new Date(v.detectedAt).toLocaleDateString()}
+                  </td>
+                  <td className="px-4 py-3 text-slate-600 font-mono">
+                    {String(v.readValue)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {/* Complaints linked to this inspection */}
+      {inspection.complaints.length > 0 && (
+        <div className="bg-white rounded-xl border border-slate-200 overflow-hidden">
+          <div className="px-5 py-3.5 border-b border-slate-100 bg-slate-50/50">
+            <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider">Related Complaints</p>
+          </div>
+          <div className="divide-y divide-slate-50">
+            {inspection.complaints.map((c: any) => (
+              <div key={c.id} className="px-5 py-3 flex items-center justify-between">
+                <div>
+                  <p className="text-sm font-medium text-slate-900">{c.source.replace(/_/g, ' ')}</p>
+                  <p className="text-xs text-slate-500 line-clamp-1">{c.description ?? 'No description'}</p>
+                </div>
+                <p className="text-xs text-slate-400">
+                  {new Date(c.createdAt).toLocaleDateString()}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/enforcement/inspections/page.tsx
+++ b/apps/web/src/app/(dashboard)/enforcement/inspections/page.tsx
@@ -1,6 +1,7 @@
 import { requireEnforcement } from '@/lib/auth.server';
 import { KpiCard } from '@/components/ui/KpiCard';
 import db from '@/lib/db';
+import Link from 'next/link';
 import { ClipboardCheck, Clock, CheckCircle, XCircle, AlertTriangle } from 'lucide-react';
 
 export default async function EnforcementInspectionsPage() {
@@ -47,7 +48,11 @@ export default async function EnforcementInspectionsPage() {
               <tr><td colSpan={6} className="px-4 py-8 text-center text-slate-400">No inspections scheduled. Inspections are created from confirmed violations.</td></tr>
             ) : inspections.map((i) => (
               <tr key={i.id} className="hover:bg-slate-50 transition-colors">
-                <td className="px-4 py-3 font-medium text-slate-900">{i.address}</td>
+                <td className="px-4 py-3 font-medium">
+                  <Link href={`/enforcement/inspections/${i.id}`} className="text-teal-600 hover:text-teal-700">
+                    {i.address}
+                  </Link>
+                </td>
                 <td className="px-4 py-3 text-slate-600">{i.assignedUser ? `${i.assignedUser.firstName} ${i.assignedUser.lastName}` : '-'}</td>
                 <td className="px-4 py-3">
                   <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${i.status === 'COMPLETE' ? 'bg-green-50 text-green-700' : i.status === 'IN_PROGRESS' ? 'bg-blue-50 text-blue-700' : i.status === 'NO_ACCESS' ? 'bg-amber-50 text-amber-700' : 'bg-slate-100 text-slate-600'}`}>{i.status.replace(/_/g, ' ')}</span>

--- a/apps/web/src/app/api/analyst/charts/route.ts
+++ b/apps/web/src/app/api/analyst/charts/route.ts
@@ -1,0 +1,87 @@
+import { NextResponse } from 'next/server';
+import { guardApi } from '@/lib/auth.server';
+import { db } from '@/lib/db';
+
+export async function GET() {
+  const authError = await guardApi('analytics:read');
+  if (authError) return authError;
+
+  const now = new Date();
+  const ninetyDaysAgo = new Date(now.getTime() - 90 * 24 * 60 * 60 * 1000);
+
+  const [violations, meterReads, zoneCounts] = await Promise.all([
+    // Violations from last 90 days for trend line
+    db.violation.findMany({
+      where: { detectedAt: { gte: ninetyDaysAgo } },
+      select: { detectedAt: true, violationType: true, status: true },
+      orderBy: { detectedAt: 'asc' },
+    }),
+
+    // Meter reads from last 90 days, grouped by label (potable/reclaimed)
+    db.meterRead.findMany({
+      where: { readTime: { gte: ninetyDaysAgo } },
+      select: { readTime: true, readValue: true, flow: true, label: true },
+      orderBy: { readTime: 'asc' },
+    }),
+
+    // Parcel counts by watering zone
+    db.parcel.groupBy({
+      by: ['wateringZone'],
+      _count: { id: true },
+      orderBy: { _count: { id: 'desc' } },
+    }),
+  ]);
+
+  // --- Violation trends: group by week ---
+  const weekMap = new Map<string, number>();
+  for (const v of violations) {
+    const d = new Date(v.detectedAt);
+    // Start of week (Sunday)
+    const weekStart = new Date(d);
+    weekStart.setDate(d.getDate() - d.getDay());
+    const key = weekStart.toISOString().slice(0, 10);
+    weekMap.set(key, (weekMap.get(key) ?? 0) + 1);
+  }
+  const violationTrend = Array.from(weekMap.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([week, count]) => ({ week, count }));
+
+  // --- Zone usage breakdown ---
+  const zoneUsage = zoneCounts.map((z: { wateringZone: string | null; _count: { id: number } }) => ({
+    zone: z.wateringZone ?? 'Unassigned',
+    count: z._count.id,
+  }));
+
+  // --- Reclaimed vs Potable usage (aggregate flow) ---
+  let potableFlow = 0;
+  let reclaimedFlow = 0;
+  for (const r of meterReads) {
+    const flow = r.flow ? Number(r.flow) : 0;
+    if (r.label === 'reclaimed') {
+      reclaimedFlow += flow;
+    } else {
+      potableFlow += flow;
+    }
+  }
+  const usageSplit = [
+    { name: 'Potable', value: Math.round(potableFlow) },
+    { name: 'Reclaimed', value: Math.round(reclaimedFlow) },
+  ];
+
+  // --- Violation type breakdown ---
+  const typeMap = new Map<string, number>();
+  for (const v of violations) {
+    const type = v.violationType.replace(/_/g, ' ');
+    typeMap.set(type, (typeMap.get(type) ?? 0) + 1);
+  }
+  const violationsByType = Array.from(typeMap.entries())
+    .sort(([, a], [, b]) => b - a)
+    .map(([type, count]) => ({ type, count }));
+
+  return NextResponse.json({
+    violationTrend,
+    zoneUsage,
+    usageSplit,
+    violationsByType,
+  });
+}

--- a/apps/web/src/app/api/inspections/[id]/route.ts
+++ b/apps/web/src/app/api/inspections/[id]/route.ts
@@ -1,0 +1,52 @@
+import { guardApi } from '@/lib/auth.server';
+import { db }       from '@/lib/db';
+
+interface Params { params: Promise<{ id: string }> }
+
+/** PATCH /api/inspections/:id — update status and/or findings */
+export async function PATCH(req: Request, { params }: Params) {
+  const guard = await guardApi('inspections:edit');
+  if (!guard.ok) return guard.response;
+
+  const { id } = await params;
+  const body = await req.json();
+
+  const inspection = await db.inspection.findUnique({ where: { id } });
+  if (!inspection) {
+    return Response.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  const data: Record<string, unknown> = {};
+
+  // Status transition
+  if (body.status && typeof body.status === 'string') {
+    const VALID_TRANSITIONS: Record<string, string[]> = {
+      SCHEDULED:   ['IN_PROGRESS', 'CANCELLED', 'NO_ACCESS'],
+      IN_PROGRESS: ['COMPLETE', 'NO_ACCESS', 'CANCELLED'],
+      NO_ACCESS:   ['SCHEDULED', 'CANCELLED'],
+    };
+    const allowed = VALID_TRANSITIONS[inspection.status];
+    if (!allowed || !allowed.includes(body.status)) {
+      return Response.json(
+        { error: `Cannot transition from ${inspection.status} to ${body.status}` },
+        { status: 422 },
+      );
+    }
+    data.status = body.status;
+    if (body.status === 'COMPLETE') {
+      data.completedDate = new Date();
+    }
+  }
+
+  // Findings / notes
+  if (typeof body.findings === 'string') {
+    data.findings = body.findings;
+  }
+
+  if (Object.keys(data).length === 0) {
+    return Response.json({ error: 'No valid fields to update' }, { status: 422 });
+  }
+
+  const updated = await db.inspection.update({ where: { id }, data });
+  return Response.json(updated);
+}

--- a/apps/web/src/components/charts/AnalystCharts.tsx
+++ b/apps/web/src/components/charts/AnalystCharts.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { ViolationTrendChart } from './ViolationTrendChart';
+import { ZoneUsageChart } from './ZoneUsageChart';
+import { UsageSplitChart } from './UsageSplitChart';
+import { ViolationTypeChart } from './ViolationTypeChart';
+
+interface ChartData {
+  violationTrend: { week: string; count: number }[];
+  zoneUsage: { zone: string; count: number }[];
+  usageSplit: { name: string; value: number }[];
+  violationsByType: { type: string; count: number }[];
+}
+
+function ChartSkeleton() {
+  return (
+    <div className="bg-white rounded-xl border border-slate-200 p-6 animate-pulse">
+      <div className="h-4 w-40 bg-slate-100 rounded mb-6" />
+      <div className="h-64 bg-slate-50 rounded" />
+    </div>
+  );
+}
+
+export function AnalystCharts() {
+  const [data, setData] = useState<ChartData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch('/api/analyst/charts')
+      .then((res) => {
+        if (!res.ok) throw new Error(`${res.status}`);
+        return res.json();
+      })
+      .then(setData)
+      .catch((err) => setError(err.message));
+  }, []);
+
+  if (error) {
+    return (
+      <div className="bg-white rounded-xl border border-red-200 p-6 text-center">
+        <p className="text-sm text-red-600">Failed to load chart data ({error})</p>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <ChartSkeleton />
+        <ChartSkeleton />
+        <ChartSkeleton />
+        <ChartSkeleton />
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <div className="bg-white rounded-xl border border-slate-200 p-6">
+        <h2 className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-4">
+          Violation Trends (Last 90 Days)
+        </h2>
+        <ViolationTrendChart data={data.violationTrend} />
+      </div>
+
+      <div className="bg-white rounded-xl border border-slate-200 p-6">
+        <h2 className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-4">
+          Parcels by Watering Zone
+        </h2>
+        <ZoneUsageChart data={data.zoneUsage} />
+      </div>
+
+      <div className="bg-white rounded-xl border border-slate-200 p-6">
+        <h2 className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-4">
+          Reclaimed vs Potable Flow
+        </h2>
+        <UsageSplitChart data={data.usageSplit} />
+      </div>
+
+      <div className="bg-white rounded-xl border border-slate-200 p-6">
+        <h2 className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-4">
+          Violations by Type (Last 90 Days)
+        </h2>
+        <ViolationTypeChart data={data.violationsByType} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/charts/UsageSplitChart.tsx
+++ b/apps/web/src/components/charts/UsageSplitChart.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import {
+  ResponsiveContainer,
+  PieChart,
+  Pie,
+  Cell,
+  Tooltip,
+  Legend,
+} from 'recharts';
+
+interface DataPoint {
+  name: string;
+  value: number;
+}
+
+const COLORS: Record<string, string> = {
+  Potable:   '#0891b2',
+  Reclaimed: '#22c55e',
+};
+
+export function UsageSplitChart({ data }: { data: DataPoint[] }) {
+  const total = data.reduce((sum, d) => sum + d.value, 0);
+
+  if (total === 0) {
+    return (
+      <div className="flex items-center justify-center h-64 text-sm text-slate-400">
+        No meter flow data available.
+      </div>
+    );
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <PieChart>
+        <Pie
+          data={data}
+          cx="50%"
+          cy="50%"
+          innerRadius={60}
+          outerRadius={100}
+          paddingAngle={3}
+          dataKey="value"
+          label={({ name, percent }: { name: string; percent: number }) =>
+            `${name} ${(percent * 100).toFixed(0)}%`
+          }
+          labelLine={{ stroke: '#94a3b8', strokeWidth: 1 }}
+        >
+          {data.map((entry) => (
+            <Cell
+              key={entry.name}
+              fill={COLORS[entry.name] ?? '#94a3b8'}
+              strokeWidth={0}
+            />
+          ))}
+        </Pie>
+        <Tooltip
+          contentStyle={{
+            fontSize: 12,
+            borderRadius: 8,
+            border: '1px solid #e2e8f0',
+            boxShadow: '0 2px 8px rgba(0,0,0,0.08)',
+          }}
+          formatter={(value: number) => [`${value.toLocaleString()} gal`, 'Flow']}
+        />
+        <Legend
+          verticalAlign="bottom"
+          iconType="circle"
+          iconSize={8}
+          wrapperStyle={{ fontSize: 12, color: '#64748b' }}
+        />
+      </PieChart>
+    </ResponsiveContainer>
+  );
+}

--- a/apps/web/src/components/charts/UsageSplitChartSection.tsx
+++ b/apps/web/src/components/charts/UsageSplitChartSection.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { UsageSplitChart } from './UsageSplitChart';
+
+interface Props {
+  data: { name: string; value: number }[];
+}
+
+export function UsageSplitChartSection({ data }: Props) {
+  return (
+    <div className="bg-white rounded-xl border border-slate-200 p-6">
+      <h2 className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-4">
+        Reclaimed vs Potable Flow (Last 90 Days)
+      </h2>
+      <UsageSplitChart data={data} />
+    </div>
+  );
+}

--- a/apps/web/src/components/charts/ViolationTrendChart.tsx
+++ b/apps/web/src/components/charts/ViolationTrendChart.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+} from 'recharts';
+
+interface DataPoint {
+  week: string;
+  count: number;
+}
+
+export function ViolationTrendChart({ data }: { data: DataPoint[] }) {
+  if (data.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-64 text-sm text-slate-400">
+        No violation trend data available.
+      </div>
+    );
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <LineChart data={data} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+        <XAxis
+          dataKey="week"
+          tick={{ fontSize: 11, fill: '#64748b' }}
+          tickFormatter={(v: string) => {
+            const d = new Date(v + 'T00:00:00');
+            return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+          }}
+        />
+        <YAxis
+          tick={{ fontSize: 11, fill: '#64748b' }}
+          allowDecimals={false}
+          width={32}
+        />
+        <Tooltip
+          contentStyle={{
+            fontSize: 12,
+            borderRadius: 8,
+            border: '1px solid #e2e8f0',
+            boxShadow: '0 2px 8px rgba(0,0,0,0.08)',
+          }}
+          labelFormatter={(v: string) => {
+            const d = new Date(v + 'T00:00:00');
+            return `Week of ${d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`;
+          }}
+        />
+        <Line
+          type="monotone"
+          dataKey="count"
+          stroke="#0d9488"
+          strokeWidth={2}
+          dot={{ r: 3, fill: '#0d9488' }}
+          activeDot={{ r: 5, strokeWidth: 0 }}
+          name="Violations"
+        />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}

--- a/apps/web/src/components/charts/ViolationTrendsCharts.tsx
+++ b/apps/web/src/components/charts/ViolationTrendsCharts.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { ViolationTrendChart } from './ViolationTrendChart';
+import { ViolationTypeChart } from './ViolationTypeChart';
+
+interface Props {
+  trendData: { week: string; count: number }[];
+  typeData: { type: string; count: number }[];
+}
+
+export function ViolationTrendsCharts({ trendData, typeData }: Props) {
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <div className="bg-white rounded-xl border border-slate-200 p-6">
+        <h2 className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-4">
+          Weekly Violation Trend (Last 90 Days)
+        </h2>
+        <ViolationTrendChart data={trendData} />
+      </div>
+      <div className="bg-white rounded-xl border border-slate-200 p-6">
+        <h2 className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-4">
+          Violations by Type
+        </h2>
+        <ViolationTypeChart data={typeData} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/charts/ViolationTypeChart.tsx
+++ b/apps/web/src/components/charts/ViolationTypeChart.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+} from 'recharts';
+
+interface DataPoint {
+  type: string;
+  count: number;
+}
+
+export function ViolationTypeChart({ data }: { data: DataPoint[] }) {
+  if (data.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-64 text-sm text-slate-400">
+        No violation type data available.
+      </div>
+    );
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart
+        data={data}
+        layout="vertical"
+        margin={{ top: 8, right: 16, left: 0, bottom: 0 }}
+      >
+        <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" horizontal={false} />
+        <XAxis
+          type="number"
+          tick={{ fontSize: 11, fill: '#64748b' }}
+          allowDecimals={false}
+        />
+        <YAxis
+          type="category"
+          dataKey="type"
+          tick={{ fontSize: 11, fill: '#64748b' }}
+          width={120}
+        />
+        <Tooltip
+          contentStyle={{
+            fontSize: 12,
+            borderRadius: 8,
+            border: '1px solid #e2e8f0',
+            boxShadow: '0 2px 8px rgba(0,0,0,0.08)',
+          }}
+          formatter={(value: number) => [value, 'Violations']}
+        />
+        <Bar
+          dataKey="count"
+          fill="#f59e0b"
+          radius={[0, 4, 4, 0]}
+          maxBarSize={28}
+        />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/apps/web/src/components/charts/ZoneUsageChart.tsx
+++ b/apps/web/src/components/charts/ZoneUsageChart.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Cell,
+} from 'recharts';
+
+interface DataPoint {
+  zone: string;
+  count: number;
+}
+
+const ZONE_COLORS: Record<string, string> = {
+  ODD:       '#0d9488',
+  EVEN:      '#0891b2',
+  MON_THU:   '#6366f1',
+  TUE_FRI:   '#8b5cf6',
+  WED_SAT:   '#d946ef',
+  RECLAIMED: '#22c55e',
+};
+const FALLBACK_COLOR = '#94a3b8';
+
+export function ZoneUsageChart({ data }: { data: DataPoint[] }) {
+  if (data.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-64 text-sm text-slate-400">
+        No zone data available.
+      </div>
+    );
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart data={data} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" vertical={false} />
+        <XAxis
+          dataKey="zone"
+          tick={{ fontSize: 11, fill: '#64748b' }}
+          tickFormatter={(v: string) => v.replace(/_/g, ' ')}
+        />
+        <YAxis
+          tick={{ fontSize: 11, fill: '#64748b' }}
+          allowDecimals={false}
+          width={32}
+        />
+        <Tooltip
+          contentStyle={{
+            fontSize: 12,
+            borderRadius: 8,
+            border: '1px solid #e2e8f0',
+            boxShadow: '0 2px 8px rgba(0,0,0,0.08)',
+          }}
+          labelFormatter={(v: string) => v.replace(/_/g, ' ')}
+          formatter={(value: number) => [value, 'Parcels']}
+        />
+        <Bar dataKey="count" radius={[4, 4, 0, 0]} maxBarSize={48}>
+          {data.map((entry) => (
+            <Cell
+              key={entry.zone}
+              fill={ZONE_COLORS[entry.zone] ?? FALLBACK_COLOR}
+            />
+          ))}
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/apps/web/src/components/charts/ZoneUsageChartSection.tsx
+++ b/apps/web/src/components/charts/ZoneUsageChartSection.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { ZoneUsageChart } from './ZoneUsageChart';
+
+interface Props {
+  data: { zone: string; count: number }[];
+}
+
+export function ZoneUsageChartSection({ data }: Props) {
+  return (
+    <div className="bg-white rounded-xl border border-slate-200 p-6">
+      <h2 className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-4">
+        Parcel Distribution by Zone
+      </h2>
+      <ZoneUsageChart data={data} />
+    </div>
+  );
+}


### PR DESCRIPTION
Analyst dashboard charts: 4 live Recharts visualizations (violation trends line, zone usage bar, reclaimed vs potable pie, violation type breakdown) powered by real Prisma data
Inspection detail page: /enforcement/inspections/[id] with summary header, status badge, editable inspector notes, status action buttons, linked violations table, related complaints
API routes: GET /api/analyst/charts for chart data, PATCH /api/inspections/:id for status transitions + findings updates